### PR TITLE
Add ansible-doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Ansible is an open source toolkit, written in Python, it is used for  Configurat
 - [semaphore](https://github.com/ansible-semaphore/semaphore) - Open Source alternative to Ansible Tower.
 - [Ansible Lint](https://github.com/ansible/ansible-lint) - Checks Playbooks for best practices and behavior that could potentially be improved.
 - [Ansible Later](https://github.com/xoxys/ansible-later) - Another best practice scanner. Checks Playbooks and Roles for best practices and behavior that could potentially be improved.
+- [Ansible Doctor](https://github.com/xoxys/ansible-doctor) - Simple annotation like documentation generator for Ansible roles based on Jinja2 templates.
 - [Ansible cmdb](https://github.com/fboender/ansible-cmdb) - Takes the output of Ansible's fact gathering and converts it into a static HTML page.
 - [ARA, Ansible Run Analysis](https://github.com/ansible-community/ara) - ARA records Ansible Playbook runs and makes the recorded data available and intuitive for users and systems.
 - [Mitogen for Ansible](https://networkgenomics.com/ansible/) - Speed up Ansible substantially with Mitogen.


### PR DESCRIPTION
ansible-doctor is a simple annotation like documentation generator based on Jinja2 templates. [Demo](https://github.com/xoxys/ansible-doctor/tree/master/example)