### PR TITLE
Add Linuxfabrik LFOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ For more information about communication, see the [Ansible communication guide](
 - [ansible-ssm](https://github.com/HQarroum/ansible-ssm) - An Ansible role to provision physical and virtual hosts with the AWS SSM agent.
 - [BlueBanquise](https://github.com/bluebanquise/bluebanquise) - An Ansible coherent roles collection to deploy clusters.
 - [redhat-cop](https://github.com/search?q=topic%3Aansible+org%3Aredhat-cop&type=Repositories&s=updated&o=desc) - Repositories with Ansible topic of the Red Hat Communities of Practice project.
+- [Linuxfabrik LFOps](https://github.com/Linuxfabrik/lfops) - An Ansible Collection with 145+ playbooks and 160+ roles to bootstrap and manage Linux infrastructure (RHEL 8/9/10, Debian, Ubuntu). Covers OS hardening, MariaDB, Icinga2, Nextcloud, FreeIPA, KVM and Bitwarden integration.
 
 ## Editor and IDE Integrations
 


### PR DESCRIPTION
Adds [Linuxfabrik LFOps](https://github.com/Linuxfabrik/lfops) to the `Playbooks, Roles and Collections` section.

LFOps is an Ansible Collection (`linuxfabrik.lfops` on Galaxy) with 145+ playbooks and 160+ roles covering the full Linux server lifecycle: provisioning, OS hardening, MariaDB, Icinga2, Nextcloud, FreeIPA, KVM, automated backups, and a Bitwarden lookup plugin for vault-backed credentials. Supports RHEL 8/9/10, Debian and Ubuntu. Ships a pre-built Execution Environment on GHCR with Mitogen pre-installed. Unlicense (public domain).

Disclosure: LFOps is Linuxfabrik's own collection, maintained by Linuxfabrik since 2017 and in production use across our own and customer fleets.