### PR TITLE
Add Ansible DocSmith

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ For more information about communication, see the [Ansible communication guide](
 - [AWX](https://github.com/ansible/awx) - Web-based user interface, REST API, and task engine built on top of Ansible. It is the upstream project for Automation Controller.
 - [Ansible Lint](https://github.com/ansible/ansible-lint) - Checks Playbooks for best practices and behavior that could potentially be improved.
 - [Ansible Doctor](https://github.com/thegeeklab/ansible-doctor) - Simple annotation like documentation generator for Ansible roles based on Jinja2 templates.
+- [Ansible DocSmith](https://github.com/foundata/ansible-docsmith) - Generates Ansible role documentation from argument_specs.yml for READMEs and default variable files.
 - [Ansible cmdb](https://github.com/fboender/ansible-cmdb) - Takes the output of Ansible's fact gathering and converts it into a static HTML page.
 - [ARA](https://github.com/ansible-community/ara) - Records Ansible playbooks and makes them easier to understand and troubleshoot with a reporting API, UI and CLI.
 - [Ansible Inventory Grapher](https://github.com/willthames/ansible-inventory-grapher) - Displays inventory inheritance hierarchies and the level at which variables are defined in an inventory.


### PR DESCRIPTION
Adds [DocSmith](https://github.com/foundata/ansible-docsmith) to the "Tools" section.

DocSmith is a documentation generator. It reads a role's [`meta/argument_specs.yml`](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#specification-format) and produces variable descriptions for the `README.md` as well as inline comment blocks for `defaults/main.yml` (or other role entry-point files). It works with roles in both [stand‑alone form](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html) and within [collections](https://docs.ansible.com/ansible/latest/collections_guide/index.html).

It also validates that your defaults and argument specs stay in sync. DocSmith is available on PyPI (`ansible-docsmith`) and works well in CI/CD pipelines or pre‑commit hooks. It also support custom templates.

**Small example results generated from [this `argument_specs.yml`](https://github.com/foundata/ansible-collection-sshd/blob/main/roles/run/meta/argument_specs.yml):**

- [Table and details of this README.md](https://github.com/foundata/ansible-collection-sshd/tree/main/roles/run#variables)
- [All inline comment blocks in this /defaults/main.yml](https://github.com/foundata/ansible-collection-sshd/blob/main/roles/run/defaults/main.yml)

**Screenshots:** https://github.com/foundata/ansible-docsmith#screenshots

**Some feedback form the forums:** https://forum.ansible.com/t/documenting-roles/42700/6
